### PR TITLE
Add JSCS in dependencies list.

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     },
 	"dependencies": {
 		"enable-global-packages": "latest",
-		"findup": "latest"
+		"findup": "latest",
+		"jscs": "latest"
 	},
 	"devDependencies": {
 		"grunt": "latest",


### PR DESCRIPTION
Currently, if you want use brackets-jscs, you must have JSCS installed on your system. This patch allow to use a JSCS embedded in the extension.