### PR TITLE
Add JSON syntax highlighting for .jscsrc config files

### DIFF
--- a/main.js
+++ b/main.js
@@ -140,4 +140,6 @@ define(function (require, exports, module) {
 		scanFile: handleLintSync,
 		scanFileAsync: handleLintAsync
 	});
+
+	LanguageManager.getLanguage('json').addFileName('.jscsrc');
 });


### PR DESCRIPTION
As the configuration file follows the JSON syntax this will make them actually have the same syntax highlighting which helps editing the files and preventing errors.
